### PR TITLE
Cookies

### DIFF
--- a/web/index_template.html
+++ b/web/index_template.html
@@ -34,41 +34,38 @@
       Note: this inline script is allowed through CSP using a hash. To change this, you must also modify the hash
     -->
     <script>
-      window.ga = function() {};
-      console.log('Analyctics disabled.');
-      // if (window.location.origin !== 'https://almannaromur.is') {
-      //   console.log('disabling analytics on non production');
-      //   window.ga = function() {};
-      // } else if (
-      //   navigator.doNotTrack === '1' ||
-      //   navigator.doNotTrack === 'yes'
-      // ) {
-      //   console.log('do not track header set, disabling analytics');
-      //   window.ga = function() {};
-      // } else {
-      //   (function(i, s, o, g, r, a, m) {
-      //     i['GoogleAnalyticsObject'] = r;
-      //     (i[r] =
-      //       i[r] ||
-      //       function() {
-      //         (i[r].q = i[r].q || []).push(arguments);
-      //       }),
-      //       (i[r].l = 1 * new Date());
-      //     (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
-      //     a.async = 1;
-      //     a.src = g;
-      //     m.parentNode.insertBefore(a, m);
-      //   })(
-      //     window,
-      //     document,
-      //     'script',
-      //     'https://www.google-analytics.com/analytics.js',
-      //     'ga'
-      //   );
-      //   ga('create', 'UA-101237170-1', 'auto');
-      //   ga('require', 'GTM-NXPCSCP');
-      //   ga('send', 'pageview');
-      // }
+      if (window.location.origin !== 'https://almannaromur.is') {
+        console.log('disabling analytics on non production');
+        window.ga = function() {};
+      } else if (
+        navigator.doNotTrack === '1' ||
+        navigator.doNotTrack === 'yes'
+      ) {
+        console.log('do not track header set, disabling analytics');
+        window.ga = function() {};
+      } else {
+        (function(i, s, o, g, r, a, m) {
+          i['GoogleAnalyticsObject'] = r;
+          (i[r] =
+            i[r] ||
+            function() {
+              (i[r].q = i[r].q || []).push(arguments);
+            }),
+            (i[r].l = 1 * new Date());
+          (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+          a.async = 1;
+          a.src = g;
+          m.parentNode.insertBefore(a, m);
+        })(
+          window,
+          document,
+          'script',
+          'https://www.google-analytics.com/analytics.js',
+          'ga'
+        );
+        ga('create', 'UA-143340605-1', 'auto');
+        ga('send', 'pageview');
+      }
     </script>
   </head>
   <body>

--- a/web/src/components/app.tsx
+++ b/web/src/components/app.tsx
@@ -45,6 +45,7 @@ import {
   LocalePropsFromState,
   LocaleLink,
 } from './locale-helpers';
+import Modal, { ModalButtons } from './modal/modal';
 import { Flags } from '../stores/flags';
 import { Cookies } from '../stores/cookies';
 import { InfoIcon } from './ui/icons';
@@ -85,7 +86,7 @@ interface LocalizedPagesState {
   hasScrolled: boolean;
   bundleGenerator: any;
   uploadPercentage?: number;
-  showCookiesBanner: boolean;
+  showCookiesModal: boolean;
   showCookiesPreference: boolean;
   statCo: boolean;
   prefCo: boolean;
@@ -100,7 +101,7 @@ let LocalizedPage: any = class extends React.Component<
     hasScrolled: false,
     bundleGenerator: null,
     uploadPercentage: null,
-    showCookiesBanner: true,
+    showCookiesModal: true,
     showCookiesPreference: false,
     statCo: false,
     prefCo: true,
@@ -120,7 +121,7 @@ let LocalizedPage: any = class extends React.Component<
     const { cookies } = this.props;
 
     if (cookies.set) {
-      this.setState({ showCookiesBanner: false });
+      this.setState({ showCookiesModal: false });
     }
 
     this.runUploads(uploads).catch(e => console.error(e));
@@ -221,7 +222,7 @@ let LocalizedPage: any = class extends React.Component<
   setCookiePreference = () => {
     const { updateCookies } = this.props;
     updateCookies({ set: true, ud: this.state.prefCo, ga: this.state.statCo });
-    this.setState({ showCookiesBanner: false, showCookiesPreference: false });
+    this.setState({ showCookiesModal: false, showCookiesPreference: false });
   };
 
   setShowCookiePreference = () => {
@@ -242,7 +243,7 @@ let LocalizedPage: any = class extends React.Component<
     const {
       bundleGenerator,
       uploadPercentage,
-      showCookiesBanner,
+      showCookiesModal,
       showCookiesPreference,
       statCo,
       prefCo,
@@ -269,102 +270,78 @@ let LocalizedPage: any = class extends React.Component<
                 }
           }
         />
-        {showCookiesBanner && !this.isDocumentPage() && (
-          <div
-            className={`cookies-banner ${
-              showCookiesPreference ? 'expanded' : ''
-            }`}>
+        {showCookiesModal && !this.isDocumentPage() && (
+          <Modal innerClassName="cookie-modal">
             <div>
-              <div className="banner-title">
+              <div className="modal-title">
                 Þessi vefsíða notar vafrakökur (e. cookies) og vefgeymslu vafra
                 (e. local storage) til að bæta upplifun þína á vefsíðunni.{' '}
                 <a href={URLS.COOKIES}>Sjá nánar</a>
               </div>
             </div>
-            <Button
-              outline
-              rounded
-              className="cont-btn"
-              onClick={() => this.setShowCookiePreference()}>
-              Áfram
-            </Button>
-            <Button
-              outline
-              rounded
-              className="save-btn"
-              onClick={() => this.setCookiePreference()}>
-              Vista
-            </Button>
-            <div className="preferences">
-              <div className="toggle-with-info">
-                <div className="pref">
-                  <h3 className="cookie-title">Frammistaða og virkni</h3>
-                  <div className="toggle-container">
-                    <div className="cookie-name">
-                      Nafn: <strong>user</strong>
-                    </div>
-                    <ToggleIs
-                      onText="Leyfa"
-                      offText="Ekki leyfa"
-                      defaultChecked={prefCo}
-                      onChange={(
-                        event: React.ChangeEvent<HTMLInputElement>
-                      ) => {
-                        this.setState({ prefCo: event.target.checked });
-                      }}
-                    />
-                  </div>
-                  <div className="info">
-                    <InfoIcon />
-                    <div className="cookie-text">
-                      Notkun vefgeymslu vafrans til að halda um upplýsingar sem
-                      bæta afköst síðunar og notendaupplifun. Þetta eru
-                      upplýsingar sem notandi hefur skráð inn, samþykktir,
-                      einstakt notanda númer, fjöldi raddsýna sem notandi hefur
-                      gefið og fjöldi raddsýna sem notandi hefur hlustað á. Með
-                      því að nota vefgeymslu vafrans á þennan hátt komum við í
-                      veg fyrir að notandi þurfi skrá inn sömu upplýsingarnar
-                      við hverja heimsókn, gefa sömu samþykki og til þess að
-                      lágmarka líkur á að notandi fái sama raddsýni oftar en
-                      einu sinni til hlustunar.
-                    </div>
-                  </div>
+            <div className="toggle-with-info">
+              <h3 className="cookie-title">Frammistaða og virkni</h3>
+              <div className="toggle-container">
+                <div className="cookie-name">
+                  Nafn: <strong>user</strong>
                 </div>
+                <ToggleIs
+                  onText="Leyfa"
+                  offText="Ekki leyfa"
+                  defaultChecked={prefCo}
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                    this.setState({ prefCo: event.target.checked });
+                  }}
+                />
               </div>
-              <div className="toggle-with-info">
-                <div className="stat">
-                  <h3 className="cookie-title">Tölfræði um notkun</h3>
-                  <div className="toggle-container">
-                    <div className="cookie-name">
-                      Nafn: <strong>ga</strong>
-                    </div>
-                    <ToggleIs
-                      onText="Leyfa"
-                      offText="Ekki leyfa"
-                      defaultChecked={statCo}
-                      onChange={(
-                        event: React.ChangeEvent<HTMLInputElement>
-                      ) => {
-                        this.setState({ statCo: event.target.checked });
-                      }}
-                    />
-                  </div>
-                  <div className="info">
-                    <InfoIcon />
-                    <div className="cookie-text">
-                      Notkun vafrakaka til að mæla notkun á ýmsum undirsíðum
-                      innan vefsíðunnar, það hjálpar okkur að meta hvað þarf að
-                      bæta, til þess notum við kökur fyrir Google Analyctics.
-                      Með því getum við séð notkunarmynstur á síðunni yfir
-                      heildina í stað þess að sjá notkun einstaka notanda. Við
-                      notum upplýsingarnar til að greina umferð á vefsíðunni en
-                      ekki til að skoða persónugreinanlegar upplýsingar.
-                    </div>
-                  </div>
+              <div className="info">
+                <InfoIcon />
+                <div className="cookie-text">
+                  Notkun vefgeymslu vafrans til að halda um upplýsingar sem bæta
+                  afköst síðunar og notendaupplifun. Þetta eru upplýsingar sem
+                  notandi hefur skráð inn, samþykki, einstakt notanda númer,
+                  fjöldi raddsýna sem notandi hefur gefið og fjöldi raddsýna sem
+                  notandi hefur hlustað á.
                 </div>
               </div>
             </div>
-          </div>
+            <div className="toggle-with-info">
+              <h3 className="cookie-title">Tölfræði um notkun</h3>
+              <div className="toggle-container">
+                <div className="cookie-name">
+                  Nafn: <strong>ga</strong>
+                </div>
+                <ToggleIs
+                  onText="Leyfa"
+                  offText="Ekki leyfa"
+                  defaultChecked={statCo}
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                    this.setState({ statCo: event.target.checked });
+                  }}
+                />
+              </div>
+              <div className="info">
+                <InfoIcon />
+                <div className="cookie-text">
+                  Notkun vafrakaka til að mæla notkun á ýmsum undirsíðum innan
+                  vefsíðunnar, það hjálpar okkur að meta hvað þarf að bæta, til
+                  þess notum við kökur fyrir Google Analyctics. Með því getum
+                  við séð notkunarmynstur á síðunni yfir heildina í stað þess að
+                  sjá notkun einstaka notanda. Við notum upplýsingarnar til að
+                  greina umferð á vefsíðunni en ekki til að skoða
+                  persónugreinanlegar upplýsingar.
+                </div>
+              </div>
+            </div>
+            <ModalButtons>
+              <Button
+                rounded
+                className="btn-grn"
+                onClick={() => this.setCookiePreference()}>
+                Áfram
+              </Button>
+            </ModalButtons>
+          </Modal>
         )}
         <LocalizationProvider bundles={bundleGenerator}>
           <div>

--- a/web/src/components/index.css
+++ b/web/src/components/index.css
@@ -83,8 +83,20 @@ a:active {
     text-decoration: underline;
 
     &:hover {
-        color: var(--blue);
+        color: var(--valid-green);
     }
+}
+
+.btn-grn {
+    margin-top: 20px;
+    align-self: center;
+    background: var(--valid-green);
+    border: 0px;
+}
+
+.btn-grn:hover {
+    background: var(--valid-green) !important;
+    color: var(--white);
 }
 
 button {
@@ -120,38 +132,51 @@ button {
     }
 }
 
-.cookies-banner {
+.cookie-modal {
     display: flex;
     flex-direction: column;
-    position: absolute;
-    top: var(--header-height);
     padding: 2rem;
-    color: var(--white);
-    background: var(--red);
     text-align: center;
     z-index: 5;
 
-    @media (--md-up) {
-        top: 0;
-    }
-
-    & .banner-title {
+    & .modal-title {
         margin-top: 0.5rem;
         margin-bottom: 0.5rem;
+        /* font-style: italic; */
     }
 
     & a {
-        color: var(--white);
+        color: var(--black);
         text-decoration: underline;
     }
 
     & .toggle-with-info {
         display: flex;
+        flex-direction: column;
 
         & .toggle-container {
-            display: flex;
             margin-bottom: 20px;
             align-items: center;
+            align-self: center;
+        }
+
+        & .toggle-input {
+            height: 30px;
+            margin-top: 5px;
+            background: var(--very-dark-grey);
+            font-size: var(--font-size-xs);
+
+            & input::before {
+                background: var(--warm-grey);
+            }
+
+            & input:checked::before {
+                background: var(--valid-green);
+            }
+
+            & div {
+                margin: 0 20px;
+            }
         }
 
         & .info {
@@ -160,6 +185,7 @@ button {
             font-size: var(--font-size-xs);
             color: var(--near-black);
             letter-spacing: 0.5px;
+            text-align: left;
         }
 
         & svg {
@@ -169,41 +195,20 @@ button {
         }
 
         & path {
-            fill: var(--white);
+            fill: var(--warm-grey);
         }
+    }
+
+    & .cookie-name {
+        font-family: var(--strong-font-family);
+        font-size: var(--font-size);
     }
 
     & .cookie-title {
         margin-top: 10px;
         margin-bottom: 10px;
-        font-size: var(--font-size-lg);
+        font-size: var(--font-size);
         font-family: var(--strong-font-family);
-    }
-
-    & .button {
-        align-self: center;
-    }
-
-    & .preferences {
-        display: none;
-    }
-
-    & .save-btn {
-        display: none;
-    }
-}
-
-.expanded {
-    & .preferences {
-        display: block;
-    }
-
-    & .save-btn {
-        display: block;
-    }
-
-    & .cont-btn {
-        display: none;
     }
 }
 

--- a/web/src/components/index.css
+++ b/web/src/components/index.css
@@ -123,7 +123,7 @@ button {
 .cookies-banner {
     display: flex;
     flex-direction: column;
-    position: sticky;
+    position: absolute;
     top: var(--header-height);
     padding: 2rem;
     color: var(--white);
@@ -135,7 +135,7 @@ button {
         top: 0;
     }
 
-    & .cookie-title {
+    & .banner-title {
         margin-top: 0.5rem;
         margin-bottom: 0.5rem;
     }
@@ -145,8 +145,65 @@ button {
         text-decoration: underline;
     }
 
+    & .toggle-with-info {
+        display: flex;
+
+        & .toggle-container {
+            display: flex;
+            margin-bottom: 20px;
+            align-items: center;
+        }
+
+        & .info {
+            display: flex;
+            flex-direction: row;
+            font-size: var(--font-size-xs);
+            color: var(--near-black);
+            letter-spacing: 0.5px;
+        }
+
+        & svg {
+            margin-inline-end: 5px;
+            flex-shrink: 0;
+            width: 22px;
+        }
+
+        & path {
+            fill: var(--white);
+        }
+    }
+
+    & .cookie-title {
+        margin-top: 10px;
+        margin-bottom: 10px;
+        font-size: var(--font-size-lg);
+        font-family: var(--strong-font-family);
+    }
+
     & .button {
         align-self: center;
+    }
+
+    & .preferences {
+        display: none;
+    }
+
+    & .save-btn {
+        display: none;
+    }
+}
+
+.expanded {
+    & .preferences {
+        display: block;
+    }
+
+    & .save-btn {
+        display: block;
+    }
+
+    & .cont-btn {
+        display: none;
     }
 }
 

--- a/web/src/components/ui/ui.tsx
+++ b/web/src/components/ui/ui.tsx
@@ -179,3 +179,15 @@ export const Toggle = ({
     </Localized>
   </div>
 );
+
+export const ToggleIs = ({
+  offText,
+  onText,
+  ...props
+}: { offText: string; onText: string } & HTMLProps<HTMLInputElement>) => (
+  <div className="toggle-input">
+    <input type="checkbox" {...props} />
+    <div>{offText}</div>
+    <div>{onText}</div>
+  </div>
+);

--- a/web/src/components/vars.css
+++ b/web/src/components/vars.css
@@ -6,6 +6,7 @@
     --green: #b7d43f;
     --valid-green: #59cbb7;
     --near-black: #4a4a4a;
+    --very-dark-grey: #b4b1b1;
     --grey: #e7e5e2;
     --darker-grey: #e6e5e3;
     --light-grey: #f3f2f0;

--- a/web/src/stores/cookies.ts
+++ b/web/src/stores/cookies.ts
@@ -1,0 +1,46 @@
+import { Dispatch } from 'redux';
+import StateTree from './tree';
+
+export namespace Cookies {
+  export interface State {
+    set: boolean;
+    ud: boolean;
+    ga: boolean;
+  }
+
+  function getDefaultState(): State {
+    return {
+      set: false,
+      ud: false,
+      ga: false,
+    };
+  }
+
+  enum ActionType {
+    UPDATE = 'UPDATE_SETTING',
+  }
+
+  interface UpdateAction {
+    type: ActionType.UPDATE;
+    state: Partial<State>;
+  }
+
+  export type Action = UpdateAction;
+
+  export const actions = {
+    update: (state: Partial<State>): UpdateAction => ({
+      type: ActionType.UPDATE,
+      state,
+    }),
+  };
+
+  export function reducer(state = getDefaultState(), action: Action): State {
+    switch (action.type) {
+      case ActionType.UPDATE:
+        return { ...state, ...action.state };
+
+      default:
+        return state;
+    }
+  }
+}

--- a/web/src/stores/flags.ts
+++ b/web/src/stores/flags.ts
@@ -28,16 +28,10 @@ export namespace Flags {
     }),
   };
 
-  // needs refactoring
+  // 'messageOverwrites' can be fetched from the sessionStorage -> disabled for now
   export function reducer(
     state: State = {
-      messageOverwrites: JSON.parse(
-        store
-          ? store.getState().user.cookiesAgreed
-            ? sessionStorage.getItem('messageOverwrites') || '{}'
-            : '{}'
-          : '{}'
-      ),
+      messageOverwrites: JSON.parse('{}'),
       homeHeroes: ['speak', 'listen'],
     },
     action: Action

--- a/web/src/stores/root.ts
+++ b/web/src/stores/root.ts
@@ -141,6 +141,10 @@ let prevUser: User.State = null;
 store.subscribe(async () => {
   const { locale, user, cookies } = store.getState();
 
+  if (cookies.set) {
+    localStorage[USER_COOKIES_AGREED] = JSON.stringify(cookies);
+  }
+
   if (cookies.ga && ga && (!prevUser || !prevUser.account) && user.account) {
     ga('set', 'userId', await hash(user.account.client_id));
     ga('send', 'pageview');

--- a/web/src/stores/root.ts
+++ b/web/src/stores/root.ts
@@ -12,17 +12,37 @@ import { Sentences } from './sentences';
 import StateTree from './tree';
 import { Uploads } from './uploads';
 import { User } from './user';
+import { Cookies } from './cookies';
 
-export const USER_KEY = 'userdata';
+export const USER_KEY = 'user';
+export const USER_COOKIES_AGREED = 'cookiesAgreed';
 
 let preloadedState = null;
-try {
-  preloadedState = {
-    user: JSON.parse(localStorage.getItem(USER_KEY)) || undefined,
-  };
-} catch (e) {
-  console.error('failed parsing storage', e);
-  localStorage.removeItem(USER_KEY);
+let fcookies =
+  JSON.parse(localStorage.getItem(USER_COOKIES_AGREED)) || undefined;
+
+preloadedState = {
+  user: undefined,
+  cookies: undefined,
+};
+
+if (fcookies) {
+  try {
+    preloadedState.cookies = fcookies;
+  } catch (e) {
+    console.error('failed parsing storage', e);
+    localStorage.removeItem(USER_COOKIES_AGREED);
+  }
+
+  if (fcookies.ud) {
+    try {
+      preloadedState.user =
+        JSON.parse(localStorage.getItem(USER_KEY)) || undefined;
+    } catch (e) {
+      console.error('failed parsing storage', e);
+      localStorage.removeItem(USER_KEY);
+    }
+  }
 }
 
 const composeEnhancers =
@@ -38,6 +58,7 @@ const store = createStore(
       locale,
       notifications,
       uploads,
+      cookies,
     }: StateTree = {
       api: undefined,
       clips: undefined,
@@ -48,6 +69,7 @@ const store = createStore(
       sentences: undefined,
       uploads: undefined,
       user: undefined,
+      cookies: undefined,
     },
     action:
       | Clips.Action
@@ -57,6 +79,7 @@ const store = createStore(
       | Sentences.Action
       | Uploads.Action
       | User.Action
+      | Cookies.Action
   ): StateTree {
     const newState = {
       clips: Clips.reducer(locale, clips, action as Clips.Action),
@@ -74,6 +97,7 @@ const store = createStore(
       notifications: Notifications.reducer(notifications, action as any),
       uploads: Uploads.reducer(uploads, action as Uploads.Action),
       user: User.reducer(user, action as User.Action),
+      cookies: Cookies.reducer(cookies, action as Cookies.Action),
     };
 
     return { api: new API(newState.locale, newState.user), ...newState };
@@ -115,27 +139,23 @@ declare const ga: any;
 
 let prevUser: User.State = null;
 store.subscribe(async () => {
-  const { locale, user } = store.getState();
+  const { locale, user, cookies } = store.getState();
 
-  // if (ga && (!prevUser || !prevUser.account) && user.account) {
-  //   ga('set', 'userId', await hash(user.account.client_id));
-  //   const { customGoal } = user.account;
-  //   if (customGoal) {
-  //     const goals = Object.keys(customGoal.current);
-  //     ga('set', 'dimension1', goals.length > 1 ? 'both' : goals[0]);
-  //   }
-  //   ga('send', 'pageview');
-  // }
+  if (cookies.ga && ga && (!prevUser || !prevUser.account) && user.account) {
+    ga('set', 'userId', await hash(user.account.client_id));
+    ga('send', 'pageview');
+  }
 
-  // for (const field of Object.keys(fieldTrackers)) {
-  //   const typedField = field as keyof User.State;
-  //   if (prevUser && user[typedField] !== prevUser[typedField]) {
-  //     fieldTrackers[typedField](locale);
-  //   }
-  // }
+  for (const field of Object.keys(fieldTrackers)) {
+    const typedField = field as keyof User.State;
+    if (prevUser && user[typedField] !== prevUser[typedField]) {
+      fieldTrackers[typedField](locale);
+    }
+  }
+
   prevUser = user;
 
-  if (user.cookiesAgreed) {
+  if (cookies.ud) {
     localStorage[USER_KEY] = JSON.stringify({
       ...user,
       account: null,
@@ -144,9 +164,8 @@ store.subscribe(async () => {
   }
 });
 
-const { user } = store.getState();
 //Only check for storage events in non-IE browsers, as it misfires in IE
-if (!(document as any).documentMode && user.cookiesAgreed) {
+if (!(document as any).documentMode && store.getState().cookies.ud) {
   window.addEventListener('storage', (storage: StorageEvent) => {
     if (storage.key === USER_KEY) {
       store.dispatch(User.actions.update(JSON.parse(storage.newValue)) as any);

--- a/web/src/stores/tree.ts
+++ b/web/src/stores/tree.ts
@@ -7,6 +7,7 @@ import { Sentences } from './sentences';
 import { RequestedLanguages } from './requested-languages';
 import { Uploads } from './uploads';
 import { User } from './user';
+import { Cookies } from './cookies';
 
 export default interface StateTree {
   api: API;
@@ -18,6 +19,7 @@ export default interface StateTree {
   sentences: Sentences.State;
   uploads: Uploads.State;
   user: User.State;
+  cookies: Cookies.State;
 }
 
 export const useTypedSelector: TypedUseSelectorHook<StateTree> = useSelector;

--- a/web/src/stores/user.ts
+++ b/web/src/stores/user.ts
@@ -15,7 +15,6 @@ export namespace User {
     validateTally: number;
     hasInfo: boolean;
     demographicInfo: DemoInfo;
-    cookiesAgreed: boolean;
 
     userClients: UserClient[];
     isFetchingAccount: boolean;
@@ -33,7 +32,6 @@ export namespace User {
       validateTally: 0,
       hasInfo: false,
       demographicInfo: { sex: '', age: '', native_language: '' },
-      cookiesAgreed: false,
       userClients: [],
       isFetchingAccount: true,
       account: null,


### PR DESCRIPTION
Changes:

- Modal prompts cookie configuration instead of banner.
- Cookies can be selected individually from the modal.
- Btm-left corner banner to open cookie config.
- Added cookiesAgreed object to localStorage which tracks which cookies are allowed.
- Individual cookies aren't used except they've been especially been allowed. (apart from the cookiesAgreed)