### PR TITLE
Empty rec hotfix

### DIFF
--- a/server/src/lib/model/db.ts
+++ b/server/src/lib/model/db.ts
@@ -22,7 +22,7 @@ const ADULTS = [
 
 // When getting new sentences/clips we need to fetch a larger pool and shuffle it to make it less
 // likely that different users requesting at the same time get the same data
-const SHUFFLE_SIZE = 500;
+const SHUFFLE_SIZE = 25000;
 
 let localeIds: { [name: string]: number };
 export async function getLocaleId(locale: string): Promise<number> {
@@ -355,7 +355,7 @@ export default class DB {
         SELECT clips.*
         FROM clips
         LEFT JOIN sentences on clips.original_sentence_id = sentences.id
-        WHERE is_valid IS NULL AND institution IS NULL AND clips.locale_id = ? AND client_id <> ? AND
+        WHERE is_valid IS NULL AND status <> 'pybossa' AND empty = 0 AND clips.locale_id = ? AND client_id <> ? AND
               NOT EXISTS(
                 SELECT *
                 FROM votes

--- a/server/src/lib/model/db/migrations/20200619093900-add-metadata-to-clips.ts
+++ b/server/src/lib/model/db/migrations/20200619093900-add-metadata-to-clips.ts
@@ -1,0 +1,17 @@
+export const up = async function(db: any): Promise<any> {
+  return db.runSql(
+    `
+      ALTER TABLE
+        clips
+      ADD COLUMN status TEXT DEFAULT NULL,
+      ADD COLUMN empty BOOLEAN DEFAULT FALSE,
+      ADD COLUMN sample_rate INTEGER DEFAULT NULL,
+      ADD COLUMN duration INTEGER DEFAULT NULL,
+      ADD COLUMN size INTEGER DEFAULT NULL
+    `
+  );
+};
+
+export const down = function(): Promise<any> {
+  return null;
+};


### PR DESCRIPTION
Added metadata to clips table: labeled clips on pybossa, clips with empty bug, sample_rate, duration and size.

Larger shuffle size when querying utterances.